### PR TITLE
Divided UserForm into two sparate forms: LoginForm and RegisterForm

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,14 +1,16 @@
 import Header from "./components/Header"
+import LoginForm from "./components/LoginForm"
+import RegisterForm from "./components/RegisterForm"
 import ThreadForm from "./components/ThreadForm"
 import ThreadList from "./components/ThreadList"
-import UserForm from "./components/UserForm"
 
 function App() {
 
   return (
     <>
       <Header />
-      <UserForm />
+      <LoginForm />
+      <RegisterForm />
       <ThreadList />
     </>
   )

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -7,7 +7,7 @@ type FormData = {
   password: string
 }
 
-function UserForm() {
+function LoginForm() {
 
   const {
     register,
@@ -18,33 +18,31 @@ function UserForm() {
 
   const { users, actions } = useUser()
 
-  const [passwordError, setPasswordError] = useState<string>("")
+  const [formError, setFormError] = useState<string>("")
   const [isSubmitted, setIsSubmitted] = useState(false)
 
   useEffect(() => {
     if (isSubmitted) {
       reset({ username: "", password: "" })
+        alert("Användare inloggad!")
     }
     setIsSubmitted(false)
-    setPasswordError("")
+    setFormError("")
     
   }, [isSubmitted, reset])
   
   const onSubmit: SubmitHandler<FormData> = (data: FormData) => {
-    const _user: User = { userName: data.username, password: data.password.trim() }
+    const _user: User = { userName: data.username.trim(), password: data.password.trim() }
     const existingUser = users.find((u) => u.userName == _user.userName)
 
     if(!existingUser) {
-      actions.createUser(_user)
-      actions.setUser(_user)
-
-      setIsSubmitted(true)      
+      setFormError("Användaren kunde inte hittas")    
     } else {
       if(existingUser.password == _user.password) {
         actions.setUser(_user)
         setIsSubmitted(true)
       } else {
-        setPasswordError("Fel lösenord")
+        setFormError("Fel lösenord")
         return
       }
     }
@@ -69,7 +67,7 @@ function UserForm() {
         </div>
 
         <div>
-          {passwordError && <p className="text-red-500 text-sm italic mb-3">{passwordError}</p>}
+          {formError && <p className="text-red-500 text-sm italic mb-3">{formError}</p>}
         </div>
 
         <div>
@@ -84,4 +82,4 @@ function UserForm() {
   )
 }
 
-export default UserForm
+export default LoginForm

--- a/src/components/RegisterForm.tsx
+++ b/src/components/RegisterForm.tsx
@@ -1,0 +1,80 @@
+import { useForm, type SubmitHandler } from 'react-hook-form'
+import { useUser } from '../contexts/UserContext'
+import { useEffect, useState } from 'react'
+
+type FormData = {
+  username: string
+  password: string
+}
+
+function RegisterForm() {
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors  },
+  } = useForm<FormData>({ defaultValues: { username: "", password: "" } })
+
+  const { users, actions } = useUser()
+
+  const [formError, setFormError] = useState<string>("")
+  const [isSubmitted, setIsSubmitted] = useState(false)
+
+  useEffect(() => {
+    if (isSubmitted == true) {
+      reset({ username: "", password: "" })
+      alert("Användare skapad och inloggad!")
+    }
+    setIsSubmitted(false)   
+    setFormError("") 
+  }, [isSubmitted, reset])
+  
+  const onSubmit: SubmitHandler<FormData> = (data: FormData) => {
+    const _user: User = { userName: data.username.trim(), password: data.password.trim() }
+    const existingUser = users.find((u) => u.userName == _user.userName)
+
+    if(!existingUser) {
+        actions.createUser(_user)
+        actions.setUser(_user)
+        setIsSubmitted(true)      
+    } else {
+        setFormError("Användarnamnet är redan taget")
+        return
+    }
+
+    return
+  }
+
+  return (
+    <div className="w-full max-w-xs">
+      <form className="bg-white shadow-md rounded px-8 pt-6 pb-8 mb-4" onSubmit={handleSubmit(onSubmit)}>
+        
+        <div className="mb-4">
+          <label className="block mb-2" >Användarnamn: </label>
+          <input className='border' {...register("username", { required: true })} />
+          {errors.username && errors.username.type === "required" && <p className="text-red-500 text-xs italic mt-1">Vänligen ange ett användarnamn</p>}
+        </div>
+
+        <div className="mb-6">
+          <label className="block mb-2">Lösenord: </label>
+          <input className='border' id='password' {...register("password", { required: true })} />
+          {errors.password && errors.password.type === "required" && <p className="text-red-500 text-xs italic mt-1">Vänligen ange ett lösenord</p>}
+        </div>
+
+        <div>
+          {formError && <p className="text-red-500 text-sm italic mb-3">{formError}</p>}
+        </div>
+
+        <div>
+          <input
+            type="submit"
+            value="Skapa ny användare"
+            className='shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline'
+          />
+        </div>
+      </form>
+    </div>
+  )
+}
+
+export default RegisterForm

--- a/src/contexts/UserContext.tsx
+++ b/src/contexts/UserContext.tsx
@@ -1,6 +1,5 @@
 import { createContext, useContext, useEffect, useState, type PropsWithChildren } from "react"
 import LocalStorageService from "../utils/LocalStorageService"
-import { dummyUsers } from "../data/users"
 
 type UserState = {
     users: User[]
@@ -27,8 +26,8 @@ function UserProvider ({ children }: PropsWithChildren) {
     const [currentUser, setCurrentUser] = useState<User | null>(defaultState.currentUser)
     
     useEffect(() => {
-      LocalStorageService.setItem('@forum/users', dummyUsers)
       _getUsers()
+      _getUser()
     }, [])
     
     const _getUsers = () => {
@@ -39,6 +38,11 @@ function UserProvider ({ children }: PropsWithChildren) {
     const _setUsers = (_users: User[]) => {
         LocalStorageService.setItem('@forum/users', _users)
         setUsers(_users)
+    }
+
+    const _getUser = () => {
+        const _user: User | null = LocalStorageService.getItem('@forum/currentUser', defaultState.currentUser)
+        setUser(_user)
     }
 
     const createUser: typeof defaultState.actions.createUser = (user) => {


### PR DESCRIPTION
Divided UserForm into two sparate forms: LoginForm and RegisterForm. Removed dummyUsers from UserContext (in order to save all users (new and old) in LocalStorage when refreshing the page)